### PR TITLE
Add sentry release tracking

### DIFF
--- a/config/custom-environment-variables.js
+++ b/config/custom-environment-variables.js
@@ -18,6 +18,9 @@ module.exports = {
     },
     auth: {
       password: "AUTH_PASSWORD"
+    },
+    heroku: {
+      slug: "HEROKU_SLUG_COMMIT"
     }
   }
 };

--- a/config/default.js
+++ b/config/default.js
@@ -28,6 +28,9 @@ module.exports = {
     },
     sentry: {
       dsn: ""
+    },
+    heroku: {
+      slug: ""
     }
   }
 };

--- a/server.js
+++ b/server.js
@@ -23,7 +23,8 @@ const services = {};
 
 Raven.config(config.sentry.dsn, {
   environment: config.environment,
-  debug: config.environment === "development"
+  debug: config.environment === "development",
+  release: config.heroku.slug
 }).install();
 
 // setup redis client


### PR DESCRIPTION
When deployed to heroku, the application will configure itself to report
any errors with the release attached to it. When combined with the
release notifications webhook that heroku sends, this allows the app to
track what release contained what errors.

Closes #27.